### PR TITLE
Update flux.js

### DIFF
--- a/src/js/store/flux.js
+++ b/src/js/store/flux.js
@@ -83,9 +83,9 @@ const getState = ({ getStore, getActions, setStore }) => {
 			noticias2: [
 				{
 					description:
-						"Dígale a la FCC: detengan la propagación de información errónea sobre el coronavirus"
+						"Dígale a la FCC: detengan la propagación de información errónea sobre el coronavirus",
 					date: "Marzo 23,2020",
-					image: "https://d3nw1if3cd9gaw.cloudfront.net/images/pet-fox-news-misinfo-covid-200319.jpg,
+					image: "https://d3nw1if3cd9gaw.cloudfront.net/images/pet-fox-news-misinfo-covid-200319.jpg",
 					type: "NOTICIAS",
 					title: "Coronavirus: Stop FakeNews!"
 				}

--- a/src/js/store/flux.js
+++ b/src/js/store/flux.js
@@ -83,17 +83,17 @@ const getState = ({ getStore, getActions, setStore }) => {
 			noticias2: [
 				{
 					description:
-						"En el inicio de la fase pública de la investigación para el impeachment de Trump en el Congreso comparecieron dos veteranos diplomáticos: William Taylor, actualmente encargado de negocios en Ucrania, y George Kent, subsecretario adjunto de Asuntos Europeos y Euroasiáticos.",
-					date: "Nov. 13, 2019",
-					image: "http://www.laconexionusa.com/fotosnoticias/g/Obamacare11.jpg",
+						"Dígale a la FCC: detengan la propagación de información errónea sobre el coronavirus"
+					date: "Marzo 23,2020",
+					image: "https://d3nw1if3cd9gaw.cloudfront.net/images/pet-fox-news-misinfo-covid-200319.jpg,
 					type: "NOTICIAS",
-					title: "Inmigrantes, con o sin documentos, pueden adquirir cobertura médica."
+					title: "Coronavirus: Stop FakeNews!"
 				}
 			],
 			noticias3: [
 				{
 					description:
-						"En el inicio de la fase pública de la investigación para el impeachment de Trump en el Congreso comparecieron dos veteranos diplomáticos: William Taylor, actualmente encargado de negocios en Ucrania, y George Kent, subsecretario adjunto de Asuntos Europeos y Euroasiáticos.",
+						"ública de la investigación para el impeachment de Trump en el Congreso comparecieron dos veteranos diplomáticos: William Taylor, actualmente encargado de negocios en Ucrania, y George Kent, subsecretario adjunto de Asuntos Europeos y Euroasiáticos.",
 					date: "Nov. 13, 2019",
 					image: "http://www.laconexionusa.com/fotosnoticias/g/16012659w.jpg",
 					type: "NOTICIAS",


### PR DESCRIPTION
Misinformation about COVID-19 will cost people their lives. And right now there’s a ton of false information about coronavirus circulating on the airwaves.

Notoriously racist radio hosts Sean Hannity, Rush Limbaugh and other right-wing broadcasters downplayed the coronavirus in the early weeks of the crisis. We need the FCC to help stop the spread of misinformation no matter where it’s coming from.

The Federal Communications Commission has rules on the books to deal with this kind of misuse and abuse of the public airwaves and has a responsibility to hold broadcasters accountable for what they air.

Sign the petition: Tell the FCC to step in and stop the spread of misinformation about COVID-19 on the public airwaves NOW.